### PR TITLE
feat: Add random wallpaper feature

### DIFF
--- a/LiveWalls/ContentView.swift
+++ b/LiveWalls/ContentView.swift
@@ -59,6 +59,15 @@ struct ContentView: View {
                         .buttonStyle(.borderedProminent)
                         .disabled(wallpaperManager.currentVideo == nil)
                         
+                        Button {
+                            wallpaperManager.setRandomWallpaper()
+                        } label: {
+                            Image(systemName: "shuffle")
+                        }
+                        .buttonStyle(.bordered)
+                        .help("Establecer fondo aleatorio")
+                        .disabled(wallpaperManager.videoFiles.isEmpty)
+
                         Spacer()
                     }
                     

--- a/LiveWalls/WallpaperManager.swift
+++ b/LiveWalls/WallpaperManager.swift
@@ -160,14 +160,16 @@ class WallpaperManager: ObservableObject {
             return
         }
 
-        if let randomVideo = videoFiles.randomElement() {
-            setActiveVideo(randomVideo)
-            // If wallpaper was already playing, or if setActiveVideo started it (e.g. if it was already the current video),
-            // ensure the new random one plays immediately.
-            // Checking isPlayingWallpaper ensures we don't start it if it was previously stopped.
-            if isPlayingWallpaper {
-                startWallpaper()
-            }
+        guard let randomVideo = videoFiles.randomElement() else {
+            return // This case will never occur because videoFiles is not empty.
+        }
+
+        setActiveVideo(randomVideo)
+        // If wallpaper was already playing, or if setActiveVideo started it (e.g. if it was already the current video),
+        // ensure the new random one plays immediately.
+        // Checking isPlayingWallpaper ensures we don't start it if it was previously stopped.
+        if isPlayingWallpaper {
+            startWallpaper()
         }
     }
     

--- a/LiveWalls/WallpaperManager.swift
+++ b/LiveWalls/WallpaperManager.swift
@@ -153,6 +153,23 @@ class WallpaperManager: ObservableObject {
     }
     
     // MARK: - Wallpaper Control
+
+    func setRandomWallpaper() {
+        guard !videoFiles.isEmpty else {
+            notificationManager.showError(message: "No videos available to set a random wallpaper.")
+            return
+        }
+
+        if let randomVideo = videoFiles.randomElement() {
+            setActiveVideo(randomVideo)
+            // If wallpaper was already playing, or if setActiveVideo started it (e.g. if it was already the current video),
+            // ensure the new random one plays immediately.
+            // Checking isPlayingWallpaper ensures we don't start it if it was previously stopped.
+            if isPlayingWallpaper {
+                startWallpaper()
+            }
+        }
+    }
     
     func startWallpaper() {
         guard let videoToPlay = currentVideo else {


### PR DESCRIPTION
This commit introduces the ability for you to set a random wallpaper from your list of available videos.

Key changes:
- Added a `setRandomWallpaper()` function to `WallpaperManager.swift`. This function selects a random video from the `videoFiles` list, sets it as active, and starts playback if a wallpaper is already playing. It also includes a notification if no videos are available.
- Added a new button with a 'shuffle' icon to `ContentView.swift` in the playback controls area. This button calls the `setRandomWallpaper()` function. The button is disabled if no videos are present in the list.

This addresses issue #1 (https://github.com/fparrav/LiveWalls/issues/1).